### PR TITLE
*downgrading to solidity 0.6.5

### DIFF
--- a/contracts/KizunaFactory.sol
+++ b/contracts/KizunaFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 import "./interfaces/IKizunaFactory.sol";
 import "./KizunaPair.sol";
@@ -40,7 +40,7 @@ contract KizunaFactory is IKizunaFactory {
         uint referrerFeeShare
     );
 
-    constructor(address feeTo_) {
+    constructor(address feeTo_) public {
         owner = msg.sender;
         feePercentOwner = msg.sender;
         setStableOwner = msg.sender;

--- a/contracts/KizunaPair.sol
+++ b/contracts/KizunaPair.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 import "./interfaces/IKizunaPair.sol";
 import "./UniswapV2ERC20.sol";
@@ -78,7 +78,7 @@ contract KizunaPair is IKizunaPair, UniswapV2ERC20 {
     event SetPairTypeImmutable();
     event Skim();
 
-    constructor() {
+    constructor() public {
         factory = msg.sender;
     }
 
@@ -160,7 +160,7 @@ contract KizunaPair is IKizunaPair, UniswapV2ERC20 {
     // update reserves
     function _update(uint balance0, uint balance1) private {
         require(
-            balance0 <= type(uint).min && balance1 <= type(uint).min,
+            balance0 <= uint112(-1) && balance1 <= uint112(-1),
             "KizunaPair: OVERFLOW"
         );
 

--- a/contracts/UniswapV2ERC20.sol
+++ b/contracts/UniswapV2ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 import "./interfaces/IUniswapV2ERC20.sol";
 import "./libraries/SafeMath.sol";
@@ -20,7 +20,7 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
         0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
     mapping(address => uint) public override nonces;
 
-    constructor() {
+    constructor() public {
         uint chainId;
         assembly {
             chainId := chainid()
@@ -79,7 +79,7 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
         address to,
         uint value
     ) external override returns (bool) {
-        if (allowance[from][msg.sender] != type(uint).min) {
+        if (allowance[from][msg.sender] != uint(-1)) {
             uint remaining = allowance[from][msg.sender].sub(value);
             allowance[from][msg.sender] = remaining;
             emit Approval(from, msg.sender, remaining);

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 interface IERC20 {
     event Approval(address indexed owner, address indexed spender, uint value);

--- a/contracts/interfaces/IKizunaFactory.sol
+++ b/contracts/interfaces/IKizunaFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 interface IKizunaFactory {
     event PairCreated(

--- a/contracts/interfaces/IKizunaPair.sol
+++ b/contracts/interfaces/IKizunaPair.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 import './IUniswapV2ERC20.sol';
 

--- a/contracts/interfaces/IUniswapV2Callee.sol
+++ b/contracts/interfaces/IUniswapV2Callee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 interface IUniswapV2Callee {
     function uniswapV2Call(

--- a/contracts/interfaces/IUniswapV2ERC20.sol
+++ b/contracts/interfaces/IUniswapV2ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 interface IUniswapV2ERC20 {
     event Approval(address indexed owner, address indexed spender, uint value);

--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 // a library for performing various math operations
 

--- a/contracts/libraries/SafeMath.sol
+++ b/contracts/libraries/SafeMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 // a library for performing overflow-safe math, courtesy of DappHub (https://github.com/dapphub/ds-math)
 

--- a/contracts/libraries/UQ112x112.sol
+++ b/contracts/libraries/UQ112x112.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 // a library for handling binary fixed point numbers (https://en.wikipedia.org/wiki/Q_(number_format))
 

--- a/contracts/test/ERC20.sol
+++ b/contracts/test/ERC20.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.6.5;
 
 import "../UniswapV2ERC20.sol";
 
 contract ERC20 is UniswapV2ERC20 {
-    constructor(uint _totalSupply) {
+    constructor(uint _totalSupply) public {
         _mint(msg.sender, _totalSupply);
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -29,7 +29,7 @@ module.exports = {
         }
       },
       {
-        version: "0.8.0",
+        version: "0.6.5",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
It appeared that Solidity has introduced lots of breaking changes since v0.8.0, especially in arithmetics: https://docs.soliditylang.org/en/latest/080-breaking-changes.html so some of the math calculation functions stopped working due to new overflow policies.

So the idea is to downgrade to the closest to the original version(0.5.16) solidity version that works well with thirdweb.